### PR TITLE
Class to Remove Discounts

### DIFF
--- a/remove_discounts.rb
+++ b/remove_discounts.rb
@@ -37,7 +37,7 @@ class RemoveDiscounts
   #
   def apply(line_item)
     # Reset discounted line price
-    new_line_price = line_item.original_line_price
+    new_line_price = line_item.line_price_was
 
     # Apply the new/reset line price to this line item with given message
     # describing the reason, which may be displayed in cart pages and

--- a/remove_discounts.rb
+++ b/remove_discounts.rb
@@ -1,0 +1,50 @@
+# RemoveDiscounts
+# ===============
+#
+# The `RemoveDiscounts` removes discounts from item prices.
+#
+# Example
+# -------
+#   * Discounts not applicable
+#
+class RemoveDiscounts
+
+  # Initializes the discount.
+  #
+  # Arguments
+  # ---------
+  #
+  # * message
+  #   The message to show for the discount.
+  #
+  def initialize(message)
+    @message = message
+  end
+
+  # Removes discounts from line item.
+  #
+  # Arguments
+  # ---------
+  #
+  # * line_item
+  #   The item from which the discounts will be removed.
+  #
+  # Example
+  # -------
+  # Given `RemoveDiscounts.new("Discounts not applicable")` and $100 item with 50% off coupon code applied:
+  #
+  # The campaign will removed 50% off discount, for $100 original price.
+  #
+  def apply(line_item)
+    # Reset discounted line price
+    new_line_price = line_item.original_line_price
+
+    # Apply the new/reset line price to this line item with given message
+    # describing the reason, which may be displayed in cart pages and
+    # confirmation emails to describe the applied adjustment.
+    line_item.change_line_price(new_line_price, message: @message)
+
+    # Print a debugging line to the console
+    puts "Reset line item with variant #{line_item.variant.id}."
+  end
+end


### PR DESCRIPTION
e.g. based on tag. Usage: _"We would like to exclude some Products from all coupon discounts"_

@gmalette – @gavinballard suggested I mention you directly to get input on this. I am trying to write a script to remove all coupon discounts from cart items that have a specific tag, using the following:

``` ruby
################################################################################
# Exclude Tagged Products from all Discounts.
################################################################################

class ExcludeFromCampaigns

  def initialize(selector, discount)
    @selector = selector
    @discount = discount
  end

  def run(cart)
    applicable_items = cart.line_items.select do |line_item|
      @selector.match?(line_item)
    end
    applicable_items.each do |line_item|
      @discount.apply(line_item)
    end
  end
end

class TagSelector
  def initialize(tag)
    @tag = tag
  end
  def match?(line_item)
    line_item.variant.product.tags.include?(@tag)
  end
end

class RemoveDiscounts
  def initialize(message)
    @message = message
  end
  def apply(line_item)
    new_line_price = line_item.line_price_was
    line_item.change_line_price(new_line_price, message: @message)
    puts line_item.line_price_was
    puts "Reset line item with variant #{line_item.variant.id}."
  end
end

CAMPAIGNS = [
  ExcludeFromCampaigns.new(
    TagSelector.new("no-discount"),
    RemoveDiscounts.new("Discounts not applicable")
  )
]

CAMPAIGNS.each do |campaign|
  campaign.run(Input.cart)
end

Output.cart = Input.cart
``` 

In my dev store admin I see the console returning the correct value for `line_item.line_price_was` and I also see `Reset line item with variant ABC123.` at least having correctly identified Variant ID. However, in the front end checkout the Product is not having its price reset.

Can you provide any insight? Is this possible?